### PR TITLE
Prevent from crashes when url doesn't exists

### DIFF
--- a/lib/Addr/Client.php
+++ b/lib/Addr/Client.php
@@ -264,8 +264,7 @@ class Client
      */
     private function completePendingLookup($id, $addr, $type)
     {
-        if(isset($this->pendingLookups[$id]['callback']))
-        {
+        if(isset($this->pendingLookups[$id])) {
             call_user_func($this->pendingLookups[$id]['callback'], $addr, $type);
         }
 


### PR DESCRIPTION
Sometimes passed domain is wrong. It crashes pending lookup because there isn't callback in stack.
