### PR TITLE
Cached null value checks

### DIFF
--- a/lib/Cache.php
+++ b/lib/Cache.php
@@ -5,6 +5,11 @@ namespace Amp\Dns;
 interface Cache {
 
     /**
+     * Default time-to-live - 1 hour
+     */
+    const DEFAULT_TTL = 3600;
+
+    /**
      * Attempt to retrieve a value from the cache
      *
      * Callback has the following signature:

--- a/lib/Cache/APCCache.php
+++ b/lib/Cache/APCCache.php
@@ -43,6 +43,14 @@ class APCCache extends KeyValueCache
      */
     public function store($name, $type, $addr, $ttl = null)
     {
+        if ($addr === null) {
+            throw new \InvalidArgumentException('Caching null addresses is disallowed');
+        }
+
+        if ($ttl === null) {
+            $ttl = self::DEFAULT_TTL;
+        }
+
         apc_store($this->generateKey($name, $type), $addr, $ttl);
     }
 

--- a/lib/Cache/MemoryCache.php
+++ b/lib/Cache/MemoryCache.php
@@ -5,10 +5,6 @@ namespace Amp\Dns\Cache;
 use Amp\Dns\Cache;
 
 class MemoryCache implements Cache {
-    /**
-     * Default time-to-live - 1 day
-     */
-    const DEFAULT_TTL = 86400;
 
     /**
      * Internal data store for cache values
@@ -32,6 +28,8 @@ class MemoryCache implements Cache {
                 $callback(true, $value);
                 return;
             }
+
+            unset($this->recordsByTypeAndName[$type][$name]);
         }
 
         $callback(false, null);
@@ -46,6 +44,10 @@ class MemoryCache implements Cache {
      * @param int $ttl
      */
     public function store($name, $type, $addr, $ttl = null) {
+        if ($addr === null) {
+            throw new \InvalidArgumentException('Caching null addresses is disallowed');
+        }
+
         if ($ttl === null) {
             $ttl = self::DEFAULT_TTL;
         }

--- a/lib/Cache/RedisCache.php
+++ b/lib/Cache/RedisCache.php
@@ -65,6 +65,14 @@ SCRIPT;
      * @param int $ttl
      */
     public function store($name, $type, $addr, $ttl = null) {
+        if ($addr === null) {
+            throw new \InvalidArgumentException('Caching null addresses is disallowed');
+        }
+
+        if ($ttl === null) {
+            $ttl = self::DEFAULT_TTL;
+        }
+
         $key = $this->generateKey($name, $type);
 
         if ($ttl > 0) {


### PR DESCRIPTION
- Prevent null values from being cached
- Delete values with expired TTLs from memory cached when an attempt is
  made to access them
- Use default TTL when none is specified with Redis and APC
