### PR TITLE
README.md file example PHP snippet fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Amp\run(function () {
     $combinedGoogleResult = (yield Amp\Dns\resolve("google.com"));
     var_dump($combinedGoogleResult);
     
-    $googleMx = (yield Amp\Dns\query("google.com", Amp\Dns\Record::MX);
+    $googleMx = (yield Amp\Dns\query("google.com", Amp\Dns\Record::MX));
     var_dump($googleMx);
 });
 ```


### PR DESCRIPTION
The example in the README.md file is missing a closing parenthesis. This PR is tiny one-liner fixing exactly that. 

Thanks for you effort on this great library. 