### PR TITLE
Fix parsing servers with port in parseCustomServerUri

### DIFF
--- a/lib/DefaultResolver.php
+++ b/lib/DefaultResolver.php
@@ -444,9 +444,9 @@ REGEX;
         if (strpos($uri, "://") !== false) {
             return $uri;
         }
-        if (($colonPos = strrpos(":", $uri)) !== false) {
+        if (($colonPos = strrpos($uri, ":")) !== false) {
             $addr = \substr($uri, 0, $colonPos);
-            $port = \substr($uri, $colonPos);
+            $port = \substr($uri, $colonPos + 1);
         } else {
             $addr = $uri;
             $port = 53;


### PR DESCRIPTION
Using `'server' => '8.8.8.8:53',` in options gave me an exception.
Found this when trying to debug issues I have when using default nameservers.