### PR TITLE
Automatically convert IPs to ARPA domain

### DIFF
--- a/lib/DefaultResolver.php
+++ b/lib/DefaultResolver.php
@@ -221,6 +221,14 @@ REGEX;
 
         assert(array_reduce($types, function ($result, $val) { return $result && \is_int($val); }, true), 'The $types passed to DNS functions must all be integers (from \Amp\Dns\Record class)');
 
+        if (($packedIp = @inet_pton($name)) !== false) {
+            if (isset($packedIp[4])) { // IPv6
+                $name = wordwrap(strrev(bin2hex($packedIp)), 1, ".", true) . ".ip6.arpa";
+            } else { // IPv4
+                $name = inet_ntop(strrev($packedIp)) . ".in-addr.arpa";
+            }
+        }
+
         $name = \strtolower($name);
         $result = [];
 

--- a/test/IntegrationTest.php
+++ b/test/IntegrationTest.php
@@ -42,6 +42,15 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase {
         });
     }
 
+    public function testPtrLoopup() {
+        \Amp\run(function () {
+            $result = (yield \Amp\Dns\query("8.8.4.4", \Amp\Dns\Record::PTR));
+            list($addr, $type) = $result[0];
+            $this->assertSame($addr, "google-public-dns-b.google.com");
+            $this->assertSame($type, \Amp\Dns\Record::PTR);
+        });
+    }
+
     public function provideHostnames() {
         return [
             ["google.com"],


### PR DESCRIPTION
Resolves #50.

I think it's fine doing that for all record types? For resolve, IP addresses are already immediately resolved and they do not end up in `onResolve`.