### PR TITLE
Make windows-registry optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,13 +33,16 @@
         "amphp/amp": "^1",
         "amphp/cache": "^0.1",
         "amphp/file": "^0.1",
-        "amphp/windows-registry": "^0.2.2",
         "daverandom/libdns": "^1"
+    },
+    "suggest": {
+        "amphp/windows-registry": "Required for applications running in Windows (^0.2.2)"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.1.3",
         "phpunit/php-code-coverage": ">=2.2",
-        "friendsofphp/php-cs-fixer": "^1.9"
+        "friendsofphp/php-cs-fixer": "^1.9",
+        "amphp/windows-registry": "^0.2.2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Currently, `amphp/windows-registry` requires a version of `amphp/process` which makes installing `amphp/aerys ^0.4.5` alongside `amphp/parallel ^0.1.0@dev` impossible. This change makes `amphp/windows-registry` an optional (suggested) dependency, which can be installed in the event the app needs to run on a Windows machine.

I have no idea how popular `amphp/dns` is with Windows users, but I imagine it's far more useful for `amphp/parallel` to work alongside `amphp/aerys`. This should become less of a problem as the libraries stabilise around Amp 2.0...