### PR TITLE
Cache DNS records based on the record requested

### DIFF
--- a/lib/DefaultResolver.php
+++ b/lib/DefaultResolver.php
@@ -634,7 +634,7 @@ REGEX;
 
         $answers = $response->getAnswerRecords();
         foreach ($answers as $record) {
-            $result[$record->getType()][] = [(string) $record->getData(), $record->getType(), $record->getTTL()];
+            $result[$type][] = [(string) $record->getData(), $record->getType(), $record->getTTL()];
         }
         if (empty($result)) {
             $this->arrayCache->set("$name#$type", [], 300); // "it MUST NOT cache it for longer than five (5) minutes" per RFC 2308 section 7.1


### PR DESCRIPTION
Currently amp/dns caches records returned from the dns server indexed by their _returned_ type instead of the _requested_ type. that means if we look up a DNAME record and instead receive a
CNAME record, it'll be cached under CNAME, leading to amp/dns making additional
requests for the DNAME record although it received a CNAME as an alternative after the first request.

This commit changes this behavior and instead caches the record with the
_requested_ type as the key rather than the returned type.