### PR TITLE
use ttl before caching

### DIFF
--- a/lib/DefaultResolver.php
+++ b/lib/DefaultResolver.php
@@ -668,7 +668,7 @@ REGEX;
         } else {
             foreach ($result as $type => $records) {
                 $minttl = INF;
-                foreach ($records as list( , $ttl)) {
+                foreach ($records as list( , , $ttl)) {
                     if ($ttl && $minttl > $ttl) {
                         $minttl = $ttl;
                     }


### PR DESCRIPTION
seems like we currently use the record type const for ttl instead of the returned value for ttl as being  set here: https://github.com/amphp/dns/compare/master...Peleg:use-ttl?expand=1#diff-95976616e9bed72530f27e1aa008eb0cR638
