### PR TITLE
Fix a precedence issue on the ConfigLoader parameter

### DIFF
--- a/lib/BasicResolver.php
+++ b/lib/BasicResolver.php
@@ -49,9 +49,9 @@ final class BasicResolver implements Resolver {
 
     public function __construct(Cache $cache = null, ConfigLoader $configLoader = null) {
         $this->cache = $cache ?? new ArrayCache;
-        $this->configLoader = $configLoader ?? \stripos(PHP_OS, "win") === 0
+        $this->configLoader = $configLoader ?? (\stripos(PHP_OS, "win") === 0
                 ? new WindowsConfigLoader
-                : new UnixConfigLoader;
+                : new UnixConfigLoader);
 
         $this->questionFactory = new QuestionFactory;
 


### PR DESCRIPTION
Fix a precedence issue where supplying your own ConfigLoader to the BasicResolver resulted in a WindowsConfigLoader being instantiated instead.