### PR TITLE
Allow global type restriction

### DIFF
--- a/lib/BasicResolver.php
+++ b/lib/BasicResolver.php
@@ -47,6 +47,9 @@ final class BasicResolver implements Resolver {
     /** @var string */
     private $gcWatcher;
 
+    /** @var int */
+    private $typeRestriction = null;
+
     public function __construct(Cache $cache = null, ConfigLoader $configLoader = null) {
         $this->cache = $cache ?? new ArrayCache;
         $this->configLoader = $configLoader ?? (\stripos(PHP_OS, "win") === 0
@@ -79,6 +82,7 @@ final class BasicResolver implements Resolver {
 
     /** @inheritdoc */
     public function resolve(string $name, int $typeRestriction = null): Promise {
+        $typeRestriction = $typeRestriction ?? $this->typeRestriction;
         if ($typeRestriction !== null && $typeRestriction !== Record::A && $typeRestriction !== Record::AAAA) {
             throw new \Error("Invalid value for parameter 2: null|Record::A|Record::AAAA expected");
         }

--- a/lib/BasicResolver.php
+++ b/lib/BasicResolver.php
@@ -80,6 +80,13 @@ final class BasicResolver implements Resolver {
         Loop::cancel($this->gcWatcher);
     }
 
+    /**
+     * @param int $typeRestriction
+     */
+    public function setTypeRestriction(int $typeRestriction) {
+        $this->typeRestriction = $typeRestriction;
+    }
+
     /** @inheritdoc */
     public function resolve(string $name, int $typeRestriction = null): Promise {
         $typeRestriction = $typeRestriction ?? $this->typeRestriction;

--- a/lib/BasicResolver.php
+++ b/lib/BasicResolver.php
@@ -50,11 +50,12 @@ final class BasicResolver implements Resolver {
     /** @var int */
     private $typeRestriction = null;
 
-    public function __construct(Cache $cache = null, ConfigLoader $configLoader = null) {
+    public function __construct(Cache $cache = null, ConfigLoader $configLoader = null, int $typeRestriction = null) {
         $this->cache = $cache ?? new ArrayCache;
         $this->configLoader = $configLoader ?? (\stripos(PHP_OS, "win") === 0
                 ? new WindowsConfigLoader
                 : new UnixConfigLoader);
+        $this->typeRestriction = $typeRestriction;
 
         $this->questionFactory = new QuestionFactory;
 
@@ -78,13 +79,6 @@ final class BasicResolver implements Resolver {
 
     public function __destruct() {
         Loop::cancel($this->gcWatcher);
-    }
-
-    /**
-     * @param int $typeRestriction
-     */
-    public function setTypeRestriction(int $typeRestriction) {
-        $this->typeRestriction = $typeRestriction;
     }
 
     /** @inheritdoc */


### PR DESCRIPTION
If a system does not have an IPv6 address, we should be able to restrict resolution globally to IPv4.
It is not possible to pass that to the resolve method all the time as the client code does not have access to the caller like in amp/socket