### PR TITLE
Change argument type of decodeCachedResult

### DIFF
--- a/lib/Rfc1035StubResolver.php
+++ b/lib/Rfc1035StubResolver.php
@@ -393,7 +393,7 @@ final class Rfc1035StubResolver implements Resolver
         return self::CACHE_PREFIX . $name . "#" . $type;
     }
 
-    private function decodeCachedResult(string $name, string $type, string $encoded)
+    private function decodeCachedResult(string $name, int $type, string $encoded)
     {
         $decoded = \json_decode($encoded, true);
 


### PR DESCRIPTION
While writing a DNS over HTTPS library based on this one I noticed this weirdness