### PR TITLE
Replaced Windows registry lookup with WMIC process invocation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,11 +36,12 @@
     "require": {
         "php": ">=8.1",
         "ext-filter": "*",
+        "ext-json": "*",
         "amphp/amp": "^3",
         "amphp/byte-stream": "^2",
         "amphp/cache": "^2",
         "amphp/parser": "^1",
-        "amphp/windows-registry": "^1.0.1",
+        "amphp/process": "^2",
         "daverandom/libdns": "^2.0.2",
         "revolt/event-loop": "^1 || ^0.2"
     },


### PR DESCRIPTION
Reading the registry is a weak solution because we don't know if the settings we're reading are from active interfaces or not. WMI, by contrast, only emits the `DNSServerSearchOrder` key (containing the DNS name servers) when the interface is actively in use (connected).

## Drawbacks
WMI is still not a perfect solution because if there are multiple active interfaces (uncommon), we don't know which interface or DNS servers Windows will actually use, but generally this is unimportant because (1) usually there's only one active interface, and (2) where there are multiple in use, if the name servers are public anyway the probability that any will work is high. Where this might be a problem is when using a VPN or other tunnel that would be unreachable from a different NIC. It is supposed there are no Windows users currently experiencing that use-case, however if there are, I do not have a solution for them.

## Deprecated approach
WMIC as an interface for WMI is actually [deprecated](https://learn.microsoft.com/en-us/windows/win32/wmisdk/wmic) (lol). Nevertheless, it's still [available by default in Windows 11](https://learn.microsoft.com/en-us/windows/whats-new/deprecated-features) at this time, but the "next version of Windows" will have it disabled by default. It is unclear to me if that means Windows 12 or the next service pack for Windows 11. In any case, we should look to move towards PowerShell in the near future, which [seems to be supported OOTB since Windows 7](https://serverfault.com/a/1065554/127896) (albeit with a diminished feature set).

![image](https://github.com/amphp/dns/assets/470626/5ab446f0-112e-45b9-aa52-c54d2dae4014)

### PowerShell
One benefit of using PowerShell is we won't need to do any output massaging since it can be tamed using various tools embedded in the shell itself. The following invocation will emit the name servers one per line.

```powershell
Get-WmiObject -Class Win32_NetworkAdapterConfiguration | Select-Object -ExpandProperty DNSServerSearchOrder
```

However, PowerShell is notably slower than WMIC. A typical benchmark on my system yields the following results.

| WMIC | PowerShell |
|-|-|
| 0.191s | 0.350s |

That is, PowerShell takes almost twice as long to output the same information. Most of this time is overhead from shell start-up, though; once in a PowerShell session, the command may execute very quickly, but this is a moot point for our use case.

## IPv6

One other observed characteristic of the `DNSServerSearchOrder` key we're querying here is that it never seems to contain IPv6 addresses. Other properties of `Win32_NetworkAdapterConfiguration` do contain references to IPv6 addresses, such as `IPAddress` and `DefaultIPGateway`, so WMI isn't IPv6-phobic itself, thus leading to a preponderance of the perpetual absence in the DNS space. There is no solution known to me at this time to retrieve the IPv6 servers by any WMI mechanism, whether we migrate to PowerShell or not.

## References

* [How does Windows decide which DNS Server to use when resolving names?](https://serverfault.com/a/1010660/127896)