### PR TITLE
Replaced WMIC nameserver lookup with PowerShell equivalent

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,11 +36,12 @@
     "require": {
         "php": ">=8.1",
         "ext-filter": "*",
+        "ext-json": "*",
         "amphp/amp": "^3",
         "amphp/byte-stream": "^2",
         "amphp/cache": "^2",
         "amphp/parser": "^1",
-        "amphp/windows-registry": "^1.0.1",
+        "amphp/process": "^2",
         "daverandom/libdns": "^2.0.2",
         "revolt/event-loop": "^1 || ^0.2"
     },


### PR DESCRIPTION
Like #115 except using PowerShell instead of WMIC. [Supported OOTB since Windows 8](https://serverfault.com/a/1065554/127896) (Windows 7 shipped with PowerShell v2, which doesn't seem to work with `Select-Object`; v3 minimum is required).

## Advantages
* Not deprecated.

## Disadvantages
* 45% slower than WMIC.

## Recommendation

Don't merge until the latest version of Windows ships without [WMIC enabled by default](https://learn.microsoft.com/en-us/windows/whats-new/deprecated-features).