### PR TITLE
Make implicit nullable types explicit

### DIFF
--- a/lib/BlockingFallbackResolver.php
+++ b/lib/BlockingFallbackResolver.php
@@ -8,7 +8,7 @@ use Amp\Success;
 
 class BlockingFallbackResolver implements Resolver
 {
-    public function resolve(string $name, int $typeRestriction = null): Promise
+    public function resolve(string $name, ?int $typeRestriction = null): Promise
     {
         if (!\in_array($typeRestriction, [Record::A, null], true)) {
             return new Failure(new DnsException("Query for '{$name}' failed, because loading the system's DNS configuration failed and querying records other than A records isn't supported in blocking fallback mode."));

--- a/lib/ConfigException.php
+++ b/lib/ConfigException.php
@@ -9,7 +9,7 @@ use Throwable;
  */
 class ConfigException extends DnsException
 {
-    public function __construct(string $message, Throwable $previous = null)
+    public function __construct(string $message, ?Throwable $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/lib/HostLoader.php
+++ b/lib/HostLoader.php
@@ -11,7 +11,7 @@ class HostLoader
 {
     private $path;
 
-    public function __construct(string $path = null)
+    public function __construct(?string $path = null)
     {
         $this->path = $path ?? $this->getDefaultPath();
     }

--- a/lib/Internal/Socket.php
+++ b/lib/Internal/Socket.php
@@ -81,7 +81,7 @@ abstract class Socket
         $this->messageFactory = new MessageFactory;
         $this->lastActivity = \time();
 
-        $this->onResolve = function (\Throwable $exception = null, Message $message = null) {
+        $this->onResolve = function (?\Throwable $exception = null, ?Message $message = null) {
             $this->lastActivity = \time();
             $this->receiving = false;
 

--- a/lib/Record.php
+++ b/lib/Record.php
@@ -60,7 +60,7 @@ final class Record
     private $type;
     private $ttl;
 
-    public function __construct(string $value, int $type, int $ttl = null)
+    public function __construct(string $value, int $type, ?int $ttl = null)
     {
         $this->value = $value;
         $this->type = $type;

--- a/lib/Resolver.php
+++ b/lib/Resolver.php
@@ -18,7 +18,7 @@ interface Resolver
      *
      * @return Promise
      */
-    public function resolve(string $name, int $typeRestriction = null): Promise;
+    public function resolve(string $name, ?int $typeRestriction = null): Promise;
 
     /**
      * Query specific DNS records.

--- a/lib/Rfc1035StubResolver.php
+++ b/lib/Rfc1035StubResolver.php
@@ -58,7 +58,7 @@ final class Rfc1035StubResolver implements Resolver
     /** @var int */
     private $nextNameserver = 0;
 
-    public function __construct(Cache $cache = null, ConfigLoader $configLoader = null)
+    public function __construct(?Cache $cache = null, ?ConfigLoader $configLoader = null)
     {
         $this->cache = $cache ?? new ArrayCache(5000 /* default gc interval */, 256 /* size */);
         $this->configLoader = $configLoader ?? (\stripos(PHP_OS, "win") === 0
@@ -93,7 +93,7 @@ final class Rfc1035StubResolver implements Resolver
     }
 
     /** @inheritdoc */
-    public function resolve(string $name, int $typeRestriction = null): Promise
+    public function resolve(string $name, ?int $typeRestriction = null): Promise
     {
         if ($typeRestriction !== null && $typeRestriction !== Record::A && $typeRestriction !== Record::AAAA) {
             throw new \Error("Invalid value for parameter 2: null|Record::A|Record::AAAA expected");
@@ -414,7 +414,7 @@ final class Rfc1035StubResolver implements Resolver
         return $promise;
     }
 
-    private function queryHosts(string $name, int $typeRestriction = null): array
+    private function queryHosts(string $name, ?int $typeRestriction = null): array
     {
         $hosts = $this->config->getKnownHosts();
         $records = [];

--- a/lib/UnixConfigLoader.php
+++ b/lib/UnixConfigLoader.php
@@ -29,7 +29,7 @@ class UnixConfigLoader implements ConfigLoader
     private $path;
     private $hostLoader;
 
-    public function __construct(string $path = "/etc/resolv.conf", HostLoader $hostLoader = null)
+    public function __construct(string $path = "/etc/resolv.conf", ?HostLoader $hostLoader = null)
     {
         $this->path = $path;
         $this->hostLoader = $hostLoader ?? new HostLoader;

--- a/lib/WindowsConfigLoader.php
+++ b/lib/WindowsConfigLoader.php
@@ -11,7 +11,7 @@ final class WindowsConfigLoader implements ConfigLoader
 {
     private $hostLoader;
 
-    public function __construct(HostLoader $hostLoader = null)
+    public function __construct(?HostLoader $hostLoader = null)
     {
         $this->hostLoader = $hostLoader ?? new HostLoader;
     }

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -14,7 +14,7 @@ const LOOP_STATE_IDENTIFIER = Resolver::class;
  *
  * @return \Amp\Dns\Resolver Returns the application-wide dns resolver instance
  */
-function resolver(Resolver $resolver = null): Resolver
+function resolver(?Resolver $resolver = null): Resolver
 {
     if ($resolver === null) {
         $resolver = Loop::getState(LOOP_STATE_IDENTIFIER);
@@ -44,7 +44,7 @@ function createDefaultResolver(): Resolver
 /**
  * @see Resolver::resolve()
  */
-function resolve(string $name, int $typeRestriction = null): Promise
+function resolve(string $name, ?int $typeRestriction = null): Promise
 {
     return resolver()->resolve($name, $typeRestriction);
 }


### PR DESCRIPTION
Branch 1.x is the one we can use with Symfony HttpClient at the moment