### PR TITLE
Fix: support for docker 26+

### DIFF
--- a/src/Rfc1035StubDnsResolver.php
+++ b/src/Rfc1035StubDnsResolver.php
@@ -148,11 +148,12 @@ final class Rfc1035StubDnsResolver implements DnsResolver
 
         foreach ($searchList as $searchIndex => $search) {
             for ($redirects = 0; $redirects < 5; $redirects++) {
-                $searchName = $name;
 
-                if ($search !== null) {
-                    $searchName = $name . "." . $search;
-                }
+                $searchName = match ($search) {
+                    null => $name,
+                    "." => $name . ".",
+                    default => $name . "." . $search,
+                };
 
                 try {
                     /** @var non-empty-list<non-empty-list<DnsRecord>> $records */


### PR DESCRIPTION
In docker 26 `/etc/resolv.conf` in containers with bridge network was updated.


docker v25:
```text
nameserver 127.0.0.11
options edns0 trust-ad ndots:0
```

in docker 26+:
```
# Generated by Docker Engine.
# This file can be edited; Docker Engine will not make further changes once it
# has been modified.

nameserver 127.0.0.11
search .
options edns0 trust-ad ndots:0

# Based on host file: '/etc/resolv.conf' (internal resolver)
# ExtServers: [1.1.1.1 127.0.0.1]

# Overrides: [nameservers]
# Option ndots from: internal
```

Additional line `search .` was added. 
This causes internal docker domains like "mysql" to resolve like "mysql..." in amp/dns, which is wrong. 
