### PR TITLE
Fix #120: Incorrect error message on missing domain

### DIFF
--- a/src/Rfc1035StubDnsResolver.php
+++ b/src/Rfc1035StubDnsResolver.php
@@ -190,13 +190,15 @@ final class Rfc1035StubDnsResolver implements DnsResolver
                     }
 
                     return \array_merge(...$records);
-                } catch (MissingDnsRecordException) {
-                    $alias = $this->searchForAliasRecord($searchName, $cancellation);
-                    if ($alias !== null) {
-                        $name = $alias;
-                    }
-                    continue;
                 } catch (DnsException $e) {
+                    if ($e instanceof MissingDnsRecordException) {
+                        $alias = $this->searchForAliasRecord($searchName, $cancellation);
+                        if ($alias !== null) {
+                            $name = $alias;
+                            continue;
+                        }
+                    }
+
                     if ($searchIndex < \count($searchList) - 1 && $this->shouldRetry($e->getCode())) {
                         continue 2;
                     }

--- a/test/Rfc1035StubResolverTest.php
+++ b/test/Rfc1035StubResolverTest.php
@@ -7,6 +7,7 @@ use Amp\Dns\DnsConfig;
 use Amp\Dns\DnsException;
 use Amp\Dns\DnsRecord;
 use Amp\Dns\InvalidNameException;
+use Amp\Dns\MissingDnsRecordException;
 use Amp\Dns\Rfc1035StubDnsResolver;
 use Amp\Dns\StaticDnsConfigLoader;
 use Amp\PHPUnit\AsyncTestCase;
@@ -93,6 +94,16 @@ class Rfc1035StubResolverTest extends AsyncTestCase
             ['get', 'amphp.dns.foo.bar#1'],
             ['get', 'amphp.dns.foo.bar#28'],
         ], $this->cacheTrainer->getOperations());
+    }
+
+    public function testNonExistingDomain(): void
+    {
+        $this->dnsConfig = new DnsConfig(['8.8.8.8:53']);
+
+        $this->expectException(MissingDnsRecordException::class);
+        $this->expectExceptionMessage('No records returned for');
+
+        $this->whenResolve('not.existing.domain.com');
     }
 
     private function whenResolve(string $name, ?int $typeRestriction = null, ?Cancellation $cancellation = null): void


### PR DESCRIPTION
I expected queries for missing domains to return a response with error code NXDomain, but it seems that is not the case for some DNS servers. Rather a response containing no records is returned.