### PR TITLE
Normalize missing DNS server ports to 53

### DIFF
--- a/src/DnsConfig.php
+++ b/src/DnsConfig.php
@@ -27,8 +27,8 @@ final class DnsConfig
             throw new DnsConfigException("At least one nameserver is required for a valid config");
         }
 
-        foreach ($nameservers as $nameserver) {
-            $this->validateNameserver($nameserver);
+        foreach ($nameservers as $key => $nameserver) {
+            $nameservers[$key] = $this->normalizeNameserver($nameserver);
         }
 
         // Windows does not include localhost in its host file. Fetch it from the system instead
@@ -141,13 +141,15 @@ final class DnsConfig
     /**
      * @throws DnsConfigException
      */
-    private function validateNameserver(string $nameserver): void
+    private function normalizeNameserver(string $nameserver): string
     {
         if ($nameserver === "") {
             throw new DnsConfigException("Invalid nameserver: empty string");
         }
 
-        if ($nameserver[0] === "[") { // IPv6
+        $isIpv6 = $nameserver[0] === "[";
+
+        if ($isIpv6) {
             $addrEnd = \strrpos($nameserver, "]");
             if ($addrEnd === false) {
                 throw new DnsConfigException("Invalid nameserver: $nameserver");
@@ -161,11 +163,15 @@ final class DnsConfig
             }
 
             $port = $port === "" ? 53 : \substr($port, 1);
-        } else { // IPv4
+        } else {
             $arr = \explode(":", $nameserver, 2);
 
             if (\count($arr) === 2) {
                 [$addr, $port] = $arr;
+
+                if (!\preg_match("(^\\d+$)", $port)) {
+                    throw new DnsConfigException("Invalid nameserver: $nameserver");
+                }
             } else {
                 $addr = $arr[0];
                 $port = 53;
@@ -182,5 +188,7 @@ final class DnsConfig
         if ($port < 1 || $port > 65535) {
             throw new DnsConfigException("Invalid server port: $port");
         }
+
+        return $isIpv6 ? "[$addr]:$port" : "$addr:$port";
     }
 }

--- a/test/DnsConfigTest.php
+++ b/test/DnsConfigTest.php
@@ -48,6 +48,7 @@ class DnsConfigTest extends AsyncTestCase
             [["foobar.com"]],
             [["127.1.1"]],
             [["127.1.1.1.1"]],
+            [["127.1.1.1:invalid"]],
             [["126.0.0.5", "foobar"]],
             [["42"]],
             [["::1"]],
@@ -107,5 +108,22 @@ class DnsConfigTest extends AsyncTestCase
     {
         $config = new DnsConfig(["127.0.0.1"]);
         self::assertFalse($config->isRotationEnabled());
+    }
+
+    public function testNormalizesServers(): void
+    {
+        $config = new DnsConfig([
+            "127.0.0.1",
+            "127.0.0.1:5353",
+            "[::1]",
+            "[::1]:5353",
+        ]);
+
+        self::assertSame([
+            "127.0.0.1:53",
+            "127.0.0.1:5353",
+            "[::1]:53",
+            "[::1]:5353",
+        ], $config->getNameservers());
     }
 }


### PR DESCRIPTION
## Summary

- normalize custom IPv4 and IPv6 nameserver addresses before storing them
- add the standard DNS port 53 when callers omit a port
- preserve explicit custom ports and reject malformed IPv4 port values
- verify the normalized endpoints returned by `DnsConfig::getNameservers()`

## Root cause

`DnsConfig` used port 53 while validating a nameserver without a port, but discarded that local default and stored the original address. The resolver later passed an incomplete endpoint such as `udp://1.1.1.1` to `stream_socket_client()`, which requires a port.

This change writes the validated, normalized endpoint back into the configuration, so callers can continue omitting the standard DNS port while the socket layer always receives a complete address.

Fixes #123.

## Validation

- `vendor/bin/phpunit test/DnsConfigTest.php test/Rfc1035StubResolverTest.php` (29 tests, 29 assertions)
- `composer cs`
- `vendor/bin/psalm.phar --no-cache`
- GitHub Actions: PHP 8.1–8.5, Windows, and macOS (7/7 jobs passed)

The complete test suite was also run locally. Three tests that depend on the local proxy DNS and timeout behavior still fail in this environment, as they did before this revision; the GitHub Actions matrix passes on all seven PHP and OS jobs.
